### PR TITLE
Expire session state as at the top level

### DIFF
--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -53,6 +53,10 @@ def _transaction(request, _db, mocker):
     @sa.event.listens_for(session, 'after_transaction_end')
     def restart_savepoint(session, trans):
         if trans.nested and not trans._parent.nested:
+            # ensure that state is expired the way
+            # session.commit() at the top level normally does
+            session.expire_all()
+
             session.begin_nested()
 
     # Force the connection to use nested transactions

--- a/tests/_conftest.py
+++ b/tests/_conftest.py
@@ -79,3 +79,35 @@ def person(request, _db):
         _db.drop_all()
 
     return Person
+
+
+@pytest.fixture(scope='module')
+def account_address(request, _db, person):
+    '''
+    Create tables to use for testing deletes and relationships.
+    '''
+    class Account(_db.Model):
+        __tablename__ = 'account'
+
+        id = _db.Column(_db.Integer, primary_key=True)
+        addresses = _db.relationship(
+            'Address',
+            back_populates='account',
+        )
+
+    class Address(_db.Model):
+        __tablename__ = 'address'
+
+        id = _db.Column(_db.Integer, primary_key=True)
+
+        account_id = _db.Column(_db.Integer, _db.ForeignKey('account.id'))
+        account = _db.relationship('Account', back_populates='addresses')
+
+    # Create tables
+    _db.create_all()
+
+    @request.addfinalizer
+    def drop_tables():
+        _db.drop_all()
+
+    return Account, Address


### PR DESCRIPTION
Fix "sqlalchemy.exc.InvalidRequestError: Instance XXX has been deleted." (#5)

Apply the "optional step" from the `after_transaction_end` listener in the "Supporting Tests with Rollbacks" sidebar of SQLAlchemy's [Joining a Session into an External Transaction (such as for test suites)](http://docs.sqlalchemy.org/en/latest/orm/session_transaction.html#session-external-transaction) documentation:

``` python
    # ensure that state is expired the way
    # session.commit() at the top level normally does
    # (optional step)
    session.expire_all()
```
I was able to replicate the error with a tiny subset of my test case in which I originally ran into the problem, and the test completes successfully with my addition to `restart_savepoint`.

However, without the fix, the test *hangs* in the last `.commit()` on an apparent deadlock between a `RELEASE SAVEPOINT` and `DROP TABLE address`. If I forcibly kill the connection (`SELECT pg_terminate_backend(pid)` on either of the two pids), the test completes, and I see the error as reported in the issue.

While that demonstrates reproducibility and the effectiveness of the fix, the hung connection is disappointing.

If I remove the ORM attribute access or change it to `id`, the test neither generates the reported error nor hangs, even without the fix.

If I remove the reference from account_inst to address_inst (`account_inst.addresses = []`) – which would be good hygiene at the Python level – the error also does not appear.