### PR TITLE
Adding MySQL support for db fixtures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ branches:
 
 language: python
 python:
+  - '3.4'
+  - '3.5'
   - '3.6'
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ branches:
 
 language: python
 python:
-  - '3.4'
-  - '3.5'
   - '3.6'
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ python:
 
 env:
   - DB=pgsql TEST_DATABASE_URL=postgresql://postgres@localhost:5432/pytest_test
+  - DB=mysql TEST_DATABASE_URL=mysql+mysqldb://root@127.0.0.1/pytest_test
 
 addons:
   postgresql: '9.6'
+  mysql: '5.7'
 
 before_script:
   - sh -c "if [ '$DB' = 'postgres' ]; then psql -c 'DROP DATABASE IF EXISTS pytest_test;' -U postgres; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ python:
   - '3.6'
 
 env:
-  - DB=sqlite
-  - DB=mysql
-  - DB=pgsql
+  - DB=pgsql TEST_DATABASE_URL=postgresql://postgres@localhost:5432/pytest_test
 
 addons:
   postgresql: '9.6'
@@ -25,23 +23,6 @@ install:
   - pip install -e .[tests]
 
 script: pytest
-
-jobs:
-  include:
-    - stage: Test PostgresSQL
-      env: DB=pgsql TEST_DATABASE_URL=postgresql://postgres@localhost:5432/pytest_test
-      addons:
-        postgresql: '9.6'
-
-    - stage: Test MySQL
-      env: DB=mysql TEST_DATABASE_URL=mysql+mysqldb://root@127.0.0.1/pytest_test
-      addons:
-        mysql: '5.7'
-
-    - stage: Test SQLite
-      env: DB=sqlite TEST_DATABASE_URL=sqlite:///:memory:/pytest_test
-      addons:
-        sqlite: '9.6'
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,40 @@ python:
   - '3.6'
 
 env:
-  - TEST_DATABASE_URL=postgresql://postgres@localhost:5432/pytest_test
+  - DB=sqlite
+  - DB=mysql
+  - DB=pgsql
 
 addons:
   postgresql: '9.6'
+
+before_script:
+  - sh -c "if [ '$DB' = 'postgres' ]; then psql -c 'DROP DATABASE IF EXISTS pytest_test;' -U postgres; fi"
+  - sh -c "if [ '$DB' = 'postgres' ]; then psql -c 'CREATE DATABASE pytest_test;' -U postgres; fi"
+  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE IF NOT EXISTS pytest_test;'; fi"
 
 install:
   - pip install --upgrade pip
   - pip install -e .[tests]
 
 script: pytest
+
+jobs:
+  include:
+    - stage: Test PostgresSQL
+      env: DB=pgsql TEST_DATABASE_URL=postgresql://postgres@localhost:5432/pytest_test
+      addons:
+        postgresql: '9.6'
+
+    - stage: Test MySQL
+      env: DB=mysql TEST_DATABASE_URL=mysql+mysqldb://root@127.0.0.1/pytest_test
+      addons:
+        mysql: '5.7'
+
+    - stage: Test SQLite
+      env: DB=sqlite TEST_DATABASE_URL=sqlite:///:memory:/pytest_test
+      addons:
+        sqlite: '9.6'
 
 deploy:
   provider: pypi

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -102,6 +102,9 @@ def _engine(pytestconfig, request, _transaction, mocker):
     # the Engine dialect to reflect tables)
     engine.dialect = connection.dialect
 
+    # Necessary for branching db test code
+    engine.name = connection.engine.name
+
     @contextlib.contextmanager
     def begin():
         '''

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
                       'pytest-mock>=1.6.2',
                       'SQLAlchemy>=1.2.2',
                       'Flask-SQLAlchemy>=2.3'],
-    extras_require={'tests': ['pytest-postgresql']},
+    extras_require={'tests': ['pytest-postgresql', 'pytest-mysql']},
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Plugins',

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -212,33 +212,57 @@ def test_drop_table(db_testdir):
     '''
     Make sure that we can drop tables and verify they do not exist in the context
     of a test.
+
+    NOTE: For MySQL `DROP TABLE ...` statements "cause an implicit commit after
+    executing. The intent is to handle each such statement in its own special
+    transaction because it cannot be rolled back anyway."
+    https://dev.mysql.com/doc/refman/5.7/en/implicit-commit.html
+
+    So this test is skipped for 'mysql' engines
     '''
+
     db_testdir.makepyfile("""
         def test_drop_table(person, db_engine):
+            if db_engine.name == 'mysql':
+                return
 
             # Drop the raw table
             db_engine.execute('''
-                DROP TABLE "person"
+                DROP TABLE person
             ''')
 
             # Check if the raw table exists
-            existing_tables = db_engine.execute('''
-                SELECT relname
-                FROM pg_catalog.pg_class
-                WHERE relkind in ('r', 'm')
-                AND relname = 'person'
-            ''').first()
+            if db_engine.name == 'postgresql':
+                existing_tables = db_engine.execute('''
+                    SELECT relname
+                    FROM pg_catalog.pg_class
+                    WHERE relkind in ('r', 'm')
+                    AND relname = 'person'
+                ''').first()
+
+            else:
+                raise ValueError(
+                    'unsupported database engine type: ' + db_engine.name
+                )
 
             assert not existing_tables
 
         def test_drop_table_changes_dont_persist(person, db_engine):
+            if db_engine.name == 'mysql':
+                return
 
-            existing_tables = db_engine.execute('''
-                SELECT relname
-                FROM pg_catalog.pg_class
-                WHERE relkind in ('r', 'm')
-                AND relname = 'person'
-            ''').first()
+            if db_engine.name == 'postgresql':
+                existing_tables = db_engine.execute('''
+                    SELECT relname
+                    FROM pg_catalog.pg_class
+                    WHERE relkind in ('r', 'm')
+                    AND relname = 'person'
+                ''').first()
+
+            else:
+                raise ValueError(
+                    'unsupported database engine type: ' + db_engine.name
+                )
 
             assert existing_tables
     """)


### PR DESCRIPTION
Adding MySQL (tested on 5.7) support with updated tests. The travis config was updated to support testing on multiple databases. I will try to tackle SQLite next.

NOTE: I skip the drop table tests for MySQL engines because the `DROP TABLE ...` statement causes an autocommit, which breaks what the test was trying to assert. After scratching my head quite a lot I found these in the MySQL docs: https://dev.mysql.com/doc/refman/5.7/en/implicit-commit.html

> "[`DROP TABLE` statements] cause an implicit commit after executing. The intent is to handle each such statement in its own special transaction because it cannot be rolled back anyway."

If anybody thinks I have misunderstood, I'll gladly take the lesson!

Refs https://github.com/jeancochrane/pytest-flask-sqlalchemy/issues/3 (kinda)