### PR TITLE
Use [tool:pytest] for section name in setup.cfg file

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ that any database changes made will be rolled back at the end of the test:
 ```ini
 # In setup.cfg
 
-[pytest]
+[tool:pytest]
 mocked-sessions=database.db.session
 mocked-engines=database.engine
 ```


### PR DESCRIPTION
Since pytest 4.0 the section name should be `[tool:pytest]` for `setup.cfg` files, while it is still `[pytest]` for `pytest.ini` and `tox.ini` files.

Reference: https://docs.pytest.org/en/latest/deprecations.html#pytest-section-in-setup-cfg-files