### PR TITLE
Support SQLAlchemy 1.3 deprecated threadlocal strategy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,18 @@ branches:
 
 language: python
 python:
-  - '3.4'
-  - '3.5'
   - '3.6'
+  - '3.5'
+  - '3.4'
 
 env:
-  - TEST_DATABASE_URL=postgresql://postgres@localhost:5432/pytest_test
+  global:
+    - TEST_DATABASE_URL=postgresql://postgres@localhost:5432/pytest_test
+
+matrix:
+  include:
+    - env: SA_VERSION=1.3.*
+    - env: SA_VERSION=1.2.*
 
 addons:
   postgresql: '9.6'
@@ -18,6 +24,7 @@ addons:
 install:
   - pip install --upgrade pip
   - pip install -e .[tests]
+  - if ![ -z "$SA_VERSION" ]; then pip install --upgrade sqlalchemy=="${SA_VERSION}"; fi
 
 script: pytest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Support SQLAlchemy 1.3 by adjusting the mock for threadlocal engine strategy [\#15](https://github.com/jeancochrane/pytest-flask-sqlalchemy/pull/15)
+
 ## [1.0.1](https://github.com/jeancochrane/pytest-flask-sqlalchemy/releases/tag/v1.0.1) (2019-03-02)
 
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
     install_requires=['pytest>=3.2.1',
                       'pytest-mock>=1.6.2',
                       'SQLAlchemy>=1.2.2',
-                      'Flask-SQLAlchemy>=2.3'],
+                      'Flask-SQLAlchemy>=2.3',
+                      'packaging>=14.1'],
     extras_require={'tests': ['pytest-postgresql']},
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
## Overview

SQLAlchemy 1.3 has deprecated the threadlocal engine strategy. This change has the side effect of making the `Engine.contextual_connect()` method private, which interferes with our mocking.

Depending on the installed version of SQLAlchemy, mock this method differently.

See:
- https://docs.sqlalchemy.org/en/latest/changelog/migration_13.html#threadlocal-engine-strategy-deprecated