### PR TITLE
Fix function definition syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ class Table(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(80))
 
-    def set_name(new_name)
+    def set_name(new_name):
         self.name = new_name
         db.session.add(self)
         db.session.commit()


### PR DESCRIPTION
This is a minor fix to the example syntax.