### PR TITLE
Attempt database connection within an exception handler

### DIFF
--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -30,10 +30,10 @@ def _transaction(request, _db, mocker):
     # Start a transaction
     try:
         connection = _db.engine.connect()
-    # SQLAlchemy's DBAPIError is the most common shared base exception class
-    # discovered while testing failures due to connection-refused (typically
-    # due to a server not present) for three common Python PostgreSQL drivers,
-    # namely psycopg2, pg8000 and py-postgresql
+    # SQLAlchemy's 'DBAPIError' is the most common shared base exception class
+    # raised when a connection to the database server is refused (typically
+    # when the server not present/running) for at least three common Python
+    # PostgreSQL drivers, namely psycopg2, pg8000 and py-postgresql
     except sa.exc.DBAPIError:
         return
 

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -30,9 +30,10 @@ def _transaction(request, _db, mocker):
     # Start a transaction
     try:
         connection = _db.engine.connect()
-        transaction = connection.begin()
-    except:
+    except sa.exc.DBAPIError:
         return
+
+    transaction = connection.begin()
 
     # Bind a session to the transaction. The empty `binds` dict is necessary
     # when specifying a `bind` option, or else Flask-SQLAlchemy won't scope

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -30,6 +30,10 @@ def _transaction(request, _db, mocker):
     # Start a transaction
     try:
         connection = _db.engine.connect()
+    # SQLAlchemy's DBAPIError is the most common shared base exception class
+    # discovered while testing failures due to connection-refused (typically
+    # due to a server not present) for three common Python PostgreSQL drivers,
+    # namely psycopg2, pg8000 and py-postgresql
     except sa.exc.DBAPIError:
         return
 

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -27,20 +27,20 @@ def _transaction(pytestconfig, request, _db, mocker):
     '''
     Create a transactional context for tests to run in.
     '''
-    # Start a transaction
     try:
         connection = _db.engine.connect()
     # Determine how to handle connection-time failures: the default behaviour
-    # is that the exceptions bubble up to the caller, but this may be changed
+    # is that the exceptions bubble up to the caller, but this may be disabled
     # via pytest configuration to allow method calls to return successfuly
     # (albeit with empty results). This can be useful to allow test-level
     # logic (including decorators) to inspect whether connectivity has been
     # established
     except sa.exc.DBAPIError:
-        if pytestconfig._handle_connect_failures:
-            return
-        raise
+        if pytestconfig._propagate_connect_exceptions:
+            raise
+        return
 
+    # Start a transaction
     transaction = connection.begin()
 
     # Bind a session to the transaction. The empty `binds` dict is necessary

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -28,8 +28,11 @@ def _transaction(request, _db, mocker):
     Create a transactional context for tests to run in.
     '''
     # Start a transaction
-    connection = _db.engine.connect()
-    transaction = connection.begin()
+    try:
+        connection = _db.engine.connect()
+        transaction = connection.begin()
+    except:
+        return
 
     # Bind a session to the transaction. The empty `binds` dict is necessary
     # when specifying a `bind` option, or else Flask-SQLAlchemy won't scope
@@ -89,6 +92,8 @@ def _engine(pytestconfig, request, _transaction, mocker):
     '''
     Mock out direct access to the semi-global Engine object.
     '''
+    if not _transaction:
+        return
     connection, _, session = _transaction
 
     # Make sure that any attempts to call `connect()` simply return a
@@ -166,6 +171,8 @@ def _session(pytestconfig, _transaction, mocker):
     Mock out Session objects (a common way of interacting with the database using
     the SQLAlchemy ORM) using a transactional context.
     '''
+    if not _transaction:
+        return
     _, _, session = _transaction
 
     # Whenever the code tries to access a Flask session, use the Session object

--- a/pytest_flask_sqlalchemy/plugin.py
+++ b/pytest_flask_sqlalchemy/plugin.py
@@ -27,7 +27,8 @@ def pytest_addoption(parser):
                   type='bool',
                   default=False,
                   help='Handle connection-time exceptions; engine and ' +
-                       'session objects will be empty on failure')
+                       'session fixtures will contain empty (None) values ' +
+                       'if SQLAlchemy could not establish a db connection')
 
 
 def pytest_configure(config):

--- a/pytest_flask_sqlalchemy/plugin.py
+++ b/pytest_flask_sqlalchemy/plugin.py
@@ -23,12 +23,13 @@ def pytest_addoption(parser):
                   type='args',
                   help=base_msg.format(obj='SQLAlchemy Sessionmaker'))
 
-    parser.addini('mocked-sessions-handle-connect-exceptions',
+    parser.addini('mocked-sessions-propagate-connect-exceptions',
                   type='bool',
-                  default=False,
-                  help='Handle connection-time exceptions; engine and ' +
-                       'session fixtures will contain empty (None) values ' +
-                       'if SQLAlchemy could not establish a db connection')
+                  default=True,
+                  help='Whether to re-raise connection-time exceptions at ' +
+                       'test runtime. If disabled, session fixtures will ' +
+                       'be set to the empty (None) value if SQLAlchemy ' +
+                       'fails to establish a database connection')
 
 
 def pytest_configure(config):
@@ -38,4 +39,4 @@ def pytest_configure(config):
     config._mocked_engines = config.getini('mocked-engines')
     config._mocked_sessions = config.getini('mocked-sessions')
     config._mocked_sessionmakers = config.getini('mocked-sessionmakers')
-    config._handle_connect_failures = config.getini('mocked-sessions-handle-connect-exceptions')
+    config._propagate_connect_exceptions = config.getini('mocked-sessions-propagate-connect-exceptions')

--- a/pytest_flask_sqlalchemy/plugin.py
+++ b/pytest_flask_sqlalchemy/plugin.py
@@ -23,6 +23,12 @@ def pytest_addoption(parser):
                   type='args',
                   help=base_msg.format(obj='SQLAlchemy Sessionmaker'))
 
+    parser.addini('mocked-sessions-handle-connect-exceptions',
+                  type='bool',
+                  default=False,
+                  help='Handle connection-time exceptions; engine and ' +
+                       'session objects will be empty on failure')
+
 
 def pytest_configure(config):
     '''
@@ -31,3 +37,4 @@ def pytest_configure(config):
     config._mocked_engines = config.getini('mocked-engines')
     config._mocked_sessions = config.getini('mocked-sessions')
     config._mocked_sessionmakers = config.getini('mocked-sessionmakers')
+    config._handle_connect_failures = config.getini('mocked-sessions-handle-connect-exceptions')

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -155,7 +155,7 @@ def test_connection_failure_transaction_empty(testdir):
             '''
             app = Flask(__name__)
 
-            app.config['SQLALCHEMY_DATABASE_URI'] = "test://test.invalid/test"
+            app.config['SQLALCHEMY_DATABASE_URI'] = "postgresql://test.invalid/test"
 
             return app
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -139,7 +139,7 @@ def test_missing_db_fixture(testdir):
 def test_connection_failure_transaction_empty(db_testdir):
     '''
     Test that when a connection cannot be established to the database, and
-    handling of connection-time exceptions is enabled, that test cases are
+    propagation of connection exceptions is disabled, that test cases are
     invoked with an empty transaction object
     '''
     conftest = """
@@ -169,7 +169,7 @@ def test_connection_failure_transaction_empty(db_testdir):
 
     db_testdir.makeini("""
         [pytest]
-        mocked-sessions-handle-connect-exceptions=true
+        mocked-sessions-propagate-connect-exceptions=false
     """)
 
     # Define a test that expects an empty transaction following a handled


### PR DESCRIPTION
This is a (very) naive approach towards handling database connection-time exceptions in the plugin, and relates to #30.