### PR TITLE
Dependencies: update to pytest >= 6, and apply fix for breaking change with that version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license='MIT',
     version='1.0.2',
     packages=['pytest_flask_sqlalchemy'],
-    install_requires=['pytest>=3.2.1',
+    install_requires=['pytest>=6.0.0',
                       'pytest-mock>=1.6.2',
                       'SQLAlchemy>=1.2.2',
                       'Flask-SQLAlchemy>=2.3',

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -129,7 +129,7 @@ def test_missing_db_fixture(testdir):
     """)
 
     result = testdir.runpytest()
-    result.assert_outcomes(error=1)
+    result.assert_outcomes(errors=1)
     result.stdout.fnmatch_lines([
         '*NotImplementedError: _db fixture not defined*'
     ])


### PR DESCRIPTION
During recent local testing of the library -- since the [release of `pytest 6.0.0` on 2020-07-28](https://github.com/pytest-dev/pytest/releases/tag/6.0.0) -- one of the unit tests has begun failing due to a change in plurality handling in `pytest` (https://github.com/pytest-dev/pytest/issues/6505).

One option to fix this would be to place a versioning constraint of strictly-less-than-v6 for pytest in the project's requirements, but generally it seems better to stay current; so this offered change requires greater-than-equal-v6 and applies a fix for the breaking change.