### PR TITLE
Handle warnings related to connection reset agent

### DIFF
--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -97,10 +97,15 @@ def _engine(pytestconfig, request, _transaction, mocker):
 
     engine.connect.return_value = connection
 
-    # Threadlocal engine strategies were deprecated in SQLAlchemy 1.3, which
-    # resulted in contextual_connect becoming a private method. See:
+    # Threadlocal engine strategies were deprecated in SQLAlchemy 1.3 and
+    # fully removed in 1.4.  The deprecation resulted in contextual_connect
+    # becoming a private method. See:
     # https://docs.sqlalchemy.org/en/latest/changelog/migration_13.html
-    if version.parse(sa.__version__) < version.parse('1.3'):
+    sa_version = version.parse(sa.__version__)
+    sa_version = version.parse(sa_version.base_version)
+    if sa_version >= version.parse('1.4'):
+        pass
+    elif sa_version < version.parse('1.3'):
         engine.contextual_connect.return_value = connection
     else:
         engine._contextual_connect.return_value = connection

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -72,12 +72,12 @@ def _transaction(request, _db, mocker):
 
     @request.addfinalizer
     def teardown_transaction():
-        # Delete the session
-        session.remove()
-
         # Rollback the transaction and return the connection to the pool
         transaction.rollback()
         connection.force_close()
+
+        # Delete the session
+        session.remove()
 
     return connection, transaction, session
 

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -40,10 +40,8 @@ def _transaction(request, _db, mocker):
     # Make sure the session, connection, and transaction can't be closed by accident in
     # the codebase
     connection.force_close = connection.close
-    transaction.force_rollback = transaction.rollback
 
     connection.close = lambda: None
-    transaction.rollback = lambda: None
     session.close = lambda: None
 
     # Begin a nested transaction (any new transactions created in the codebase
@@ -78,7 +76,7 @@ def _transaction(request, _db, mocker):
         session.remove()
 
         # Rollback the transaction and return the connection to the pool
-        transaction.force_rollback()
+        transaction.rollback()
         connection.force_close()
 
     return connection, transaction, session


### PR DESCRIPTION
This is an attempt to handle the issues raised in #36.

The upstream reset agent handling logic in `sqlalchemy` appears to have been changing recently and it *may* be the case that the message appearing from version `1.3.17` is harmless.  Even so it seemed worth taking a look to see whether there's a way to reduce the warning noise without causing breakage.

The changes applied here allow tests to pass without errors or warnings for both [`pytest-flask-sqlalchemy`](https://github.com/jeancochrane/pytest-flask-sqlalchemy/) and the [`flaskdb`](https://github.com/VioletRainbows/flaskdb) issue repro repository when using the [current `master` branch of `sqlalchemy`](https://github.com/sqlalchemy/sqlalchemy/tree/3d5a64ac09b55514da6fd30f0f085348c2d10496).

The issue repro repository tests do still report a warning after these changes are applied when using `sqlalchemy` `1.3.18`.

Major caveat: I'm not fully sure of all the interactions between the various database engine, session, connection and transaction objects taking place across all these libraries; I've addressed the symptoms here but it's possible that this isn't the most correct fix.

Addresses / fixes #36.