### PR TITLE
Fix tests by  altering 'errors' kwarg in assert_outcomes() to match pytest 6.x API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
                       'SQLAlchemy>=1.2.2',
                       'Flask-SQLAlchemy>=2.3',
                       'packaging>=14.1'],
-    extras_require={'tests': ['pytest-postgresql>=2.4.0', 'psycopg2-binary']},
+    extras_require={'tests': ['pytest-postgresql>=2.4.0', 'psycopg2-binary', 'pytest>=6.0.1']},
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Plugins',

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -130,7 +130,7 @@ def test_missing_db_fixture(testdir):
     """)
 
     result = testdir.runpytest()
-    result.assert_outcomes(error=1)
+    result.assert_outcomes(errors=1)
     result.stdout.fnmatch_lines([
         '*NotImplementedError: _db fixture not defined*'
     ])


### PR DESCRIPTION
Looks like pytest 6.x changed the [`assert_outcomes()` API](https://docs.pytest.org/en/stable/reference.html#_pytest.pytester.RunResult.assert_outcomes) so that `error` is now `errors`. This is causing our tests to fail when the latest version of Pytest is installed. This PR updates the `tests` requirements to pin Pytest to `>=6.0.1` and adjusts `tests/test_configs.py::test_missing_db_fixture` to use the new `errors` kwarg when calling `assert_outcomes()`.