### PR TITLE
expunge instances before restarting nested transaction

### DIFF
--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -56,7 +56,7 @@ def _transaction(request, _db, mocker):
         if trans.nested and not trans._parent.nested:
             # ensure that state is expired the way
             # session.commit() at the top level normally does
-            session.expire_all()
+            session.expunge_all()
 
             session.begin_nested()
 


### PR DESCRIPTION
Should this call `expunge_all` instead of `expire_all`?

I'm seeing some test failures with stale instances that hit https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_3_19/lib/sqlalchemy/orm/session.py#L2603 if only `expire_all` is called.

At this point, uncommitted instances can be disregarded I believe?