### PR TITLE
call make_transient on instance during rehydration if adding fails

### DIFF
--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -73,6 +73,8 @@ def _transaction(request, _db, mocker):
         try:
             session.add(obj)
         except sa.exc.InvalidRequestError:
+            # If the object has been deleted we need to add it back to the session context
+            # See: https://github.com/sqlalchemy/sqlalchemy/blob/da4e4cb1c67230abd67e487cfb1bda8cd6910029/lib/sqlalchemy/orm/session.py#L2343
             sa.orm.session.make_transient(obj)
 
     @request.addfinalizer

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -70,7 +70,10 @@ def _transaction(request, _db, mocker):
     @sa.event.listens_for(session, 'persistent_to_detached')
     @sa.event.listens_for(session, 'deleted_to_detached')
     def rehydrate_object(session, obj):
-        session.add(obj)
+        try:
+            session.add(obj)
+        except sa.exc.InvalidRequestError:
+            sa.orm.session.make_transient(obj)
 
     @request.addfinalizer
     def teardown_transaction():


### PR DESCRIPTION
I'm getting this exception https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_3_19/lib/sqlalchemy/orm/session.py#L2343 in some of my tests where a record is accessed and then deleted. Per the upstream recommendation, this captures that exception and tries calling `make_transient` instead.

All other errors are (re-)thrown