### PR TITLE
Add custom marker to skip tests selectively when database connectivity is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ transactions using [Flask-SQLAlchemy](http://flask-sqlalchemy.pocoo.org/latest/)
             - [`mocked-sessions`](#mocked-sessions)
             - [`mocked-sessionmakers`](#mocked-sessionmakers)
         - [Writing transactional tests](#writing-transactional-tests)
+        - [Connectivity-conditional tests](#connectivity-conditional-tests)
     - [Fixtures](#fixtures)
         - [`db_session`](#db_session)
         - [`db_engine`](#db_engine)
@@ -390,6 +391,29 @@ For more information about the transactional fixtures provided by this module, r
 to the [fixtures section](#fixtures). For guidance on how to automatically enable
 transactions without having to specify fixtures, see the section on [enabling transactions
 without fixtures](#enabling-transactions-without-fixtures).
+
+### <a name="connectivity-conditional-tests"></a>Connectivity-conditional tests
+
+This plugin provides a [custom marker](https://docs.pytest.org/en/latest/writing_plugins.html#registering-custom-markers) that allows you to selectively skip unit tests if database connectivity cannot be established.
+
+To use the marker, you must configure the plugin to catch database connection exceptions:
+
+```ini
+# In setup.cfg
+
+[tool:pytest]
+mocked-sessions-propagate-connect-exceptions=false
+```
+
+And then add the corresponding `pytest.mark` decorator to each connectivity-conditional test:
+
+```python
+@pytest.mark.requires_sqlalchemy_connection
+def test_crud_operations(db_session):
+    # this test case will only run if a database connection can be established,
+    # otherwise it will appear as a 'skipped' test according to the pytest report
+    assert False
+```
 
 ## <a name="fixtures"></a>Fixtures
 

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ without fixtures](#enabling-transactions-without-fixtures).
 
 ### <a name="connectivity-conditional-tests"></a>Connectivity-conditional tests
 
-This plugin provides a [custom marker](https://docs.pytest.org/en/latest/writing_plugins.html#registering-custom-markers) that allows you to selectively skip unit tests if database connectivity cannot be established.
+This plugin provides a [`pytest` custom marker](https://docs.pytest.org/en/latest/writing_plugins.html#registering-custom-markers) that allows you to selectively skip unit tests if database connectivity cannot be established.
 
 To use the marker, you must configure the plugin to catch database connection exceptions:
 

--- a/README.md
+++ b/README.md
@@ -396,16 +396,7 @@ without fixtures](#enabling-transactions-without-fixtures).
 
 This plugin provides a [`pytest` custom marker](https://docs.pytest.org/en/latest/writing_plugins.html#registering-custom-markers) that allows you to selectively skip unit tests if database connectivity cannot be established when the test is run.
 
-To use the marker, you must configure the plugin to catch database connection exceptions:
-
-```ini
-# In setup.cfg
-
-[tool:pytest]
-mocked-sessions-propagate-connect-exceptions=false
-```
-
-And then add the corresponding `pytest.mark` decorator to each connectivity-conditional test:
+To use the marker, add the corresponding `pytest.mark` decorator to each connectivity-conditional test:
 
 ```python
 @pytest.mark.requires_sqlalchemy_connection

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ without fixtures](#enabling-transactions-without-fixtures).
 
 ### <a name="connectivity-conditional-tests"></a>Connectivity-conditional tests
 
-This plugin provides a [`pytest` custom marker](https://docs.pytest.org/en/latest/writing_plugins.html#registering-custom-markers) that allows you to selectively skip unit tests if database connectivity cannot be established.
+This plugin provides a [`pytest` custom marker](https://docs.pytest.org/en/latest/writing_plugins.html#registering-custom-markers) that allows you to selectively skip unit tests if database connectivity cannot be established when the test is run.
 
 To use the marker, you must configure the plugin to catch database connection exceptions:
 

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -29,10 +29,10 @@ def _transaction(request, _db, mocker):
     '''
     try:
         connection = _db.engine.connect()
-    # Determine how to handle connection-time failures: the default behaviour
-    # is that the exceptions bubble up to the caller.  However, if the test
-    # has a marker to indicate that it is dependent on database connectivity,
-    # then issue a pytest 'skip' result for the test.
+    # Handle connection-time failures: the default behaviour is that exceptions
+    # are re-raised, which will typically result in a test failure.  This can
+    # be overridden by a decorator to indicate that the test is conditional on
+    # database connectivity; in that case the test will be skipped.
     except sa.exc.DBAPIError as e:
         if request.node.get_closest_marker('requires_sqlalchemy_connection'):
             pytest.skip(msg='Test skipped due to database connect() exception: {e}'.format(e=e))

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -33,9 +33,9 @@ def _transaction(request, _db, mocker):
     # is that the exceptions bubble up to the caller.  However, if the test
     # has a marker to indicate that it is dependent on database connectivity,
     # then issue a pytest 'skip' result for the test.
-    except sa.exc.DBAPIError:
+    except sa.exc.DBAPIError as e:
         if request.node.get_closest_marker('requires_sqlalchemy_connection'):
-            pytest.skip()
+            pytest.skip(msg='Test skipped due to database connect() exception: {e}'.format(e=e))
         raise
 
     # Start a transaction

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -36,6 +36,7 @@ def _transaction(request, _db, mocker):
     except sa.exc.DBAPIError as e:
         if request.node.get_closest_marker('requires_sqlalchemy_connection'):
             pytest.skip(msg='Test skipped due to database connect() exception: {e}'.format(e=e))
+            return
         raise
 
     # Start a transaction

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -30,11 +30,9 @@ def _transaction(request, _db, mocker):
     try:
         connection = _db.engine.connect()
     # Determine how to handle connection-time failures: the default behaviour
-    # is that the exceptions bubble up to the caller, but this may be disabled
-    # via pytest configuration to allow method calls to return successfuly
-    # (albeit with empty results). This can be useful to allow test-level
-    # logic (including decorators) to inspect whether connectivity has been
-    # established
+    # is that the exceptions bubble up to the caller.  However, if the test
+    # has a marker to indicate that it is dependent on database connectivity,
+    # then issue a pytest 'skip' result for the test.
     except sa.exc.DBAPIError:
         if request.node.get_closest_marker('requires_sqlalchemy_connection'):
             pytest.skip()

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -217,12 +217,12 @@ def db_engine(_engine, _session, _transaction):
 
 
 @pytest.fixture(autouse=True)
-def _skip_when_transaction_unavailable(request, _transaction):
+def _requires_sqlalchemy_connection(request, _transaction):
     '''
     This auto-use fixture allows users of the plugin to decorate test methods
     with a marker indicating that they should be skipped by pytest when a
-    database transaction cannot be created.
+    database connection cannot be established.
     '''
-    if request.node.get_closest_marker('skip_when_transaction_unavailable'):
+    if request.node.get_closest_marker('requires_sqlalchemy_connection'):
         if not _transaction:
             pytest.skip()

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -214,3 +214,15 @@ def db_engine(_engine, _session, _transaction):
     SQLAlchemy Engine API.
     '''
     return _engine
+
+
+@pytest.fixture(autouse=True)
+def _skip_when_transaction_unavailable(request, _transaction):
+    '''
+    This auto-use fixture allows users of the plugin to decorate test methods
+    with a marker indicating that they should be skipped by pytest when a
+    database transaction cannot be created.
+    '''
+    if request.node.get_closest_marker('skip_when_transaction_unavailable'):
+        if not _transaction:
+            pytest.skip()

--- a/pytest_flask_sqlalchemy/plugin.py
+++ b/pytest_flask_sqlalchemy/plugin.py
@@ -31,4 +31,4 @@ def pytest_configure(config):
     config._mocked_engines = config.getini('mocked-engines')
     config._mocked_sessions = config.getini('mocked-sessions')
     config._mocked_sessionmakers = config.getini('mocked-sessionmakers')
-    config.addinivalue_line('markers', 'requires_sqlalchemy_connection: only run this test if a database connection can be established by pytest-flask-sqlalchemy')
+    config.addinivalue_line('markers', 'requires_sqlalchemy_connection: skip the given test function if a database connection cannot be established by pytest-flask-sqlalchemy when it runs')

--- a/pytest_flask_sqlalchemy/plugin.py
+++ b/pytest_flask_sqlalchemy/plugin.py
@@ -1,4 +1,4 @@
-from .fixtures import _db, _transaction, _engine, _session, _skip_when_transaction_unavailable, db_session, db_engine
+from .fixtures import _db, _transaction, _engine, _session, _requires_sqlalchemy_connection, db_session, db_engine
 
 
 def pytest_addoption(parser):
@@ -31,4 +31,4 @@ def pytest_configure(config):
     config._mocked_engines = config.getini('mocked-engines')
     config._mocked_sessions = config.getini('mocked-sessions')
     config._mocked_sessionmakers = config.getini('mocked-sessionmakers')
-    config.addinivalue_line('markers', 'skip_when_transaction_unavailable')
+    config.addinivalue_line('markers', 'requires_sqlalchemy_connection')

--- a/pytest_flask_sqlalchemy/plugin.py
+++ b/pytest_flask_sqlalchemy/plugin.py
@@ -1,4 +1,4 @@
-from .fixtures import _db, _transaction, _engine, _session, _requires_sqlalchemy_connection, db_session, db_engine
+from .fixtures import _db, _transaction, _engine, _session, db_session, db_engine
 
 
 def pytest_addoption(parser):

--- a/pytest_flask_sqlalchemy/plugin.py
+++ b/pytest_flask_sqlalchemy/plugin.py
@@ -31,4 +31,4 @@ def pytest_configure(config):
     config._mocked_engines = config.getini('mocked-engines')
     config._mocked_sessions = config.getini('mocked-sessions')
     config._mocked_sessionmakers = config.getini('mocked-sessionmakers')
-    config.addinivalue_line('markers', 'requires_sqlalchemy_connection')
+    config.addinivalue_line('markers', 'requires_sqlalchemy_connection: only run this test if a database connection can be established by pytest-flask-sqlalchemy')

--- a/pytest_flask_sqlalchemy/plugin.py
+++ b/pytest_flask_sqlalchemy/plugin.py
@@ -1,4 +1,4 @@
-from .fixtures import _db, _transaction, _engine, _session, db_session, db_engine
+from .fixtures import _db, _transaction, _engine, _session, _skip_when_transaction_unavailable, db_session, db_engine
 
 
 def pytest_addoption(parser):
@@ -31,3 +31,4 @@ def pytest_configure(config):
     config._mocked_engines = config.getini('mocked-engines')
     config._mocked_sessions = config.getini('mocked-sessions')
     config._mocked_sessionmakers = config.getini('mocked-sessionmakers')
+    config.addinivalue_line('markers', 'skip_when_transaction_unavailable')


### PR DESCRIPTION
Add support for a [`pytest` custom marker](https://docs.pytest.org/en/stable/example/markers.html) that allows users to skip tests selectively when a database connection cannot be established at test-time.

### Usage example
```python
@pytest.mark.requires_sqlalchemy_connection
def test_crud_operations(db_session):
    # this test case will only run if a database connection can be established,
    # otherwise it will appear as a 'skipped' test according to the pytest report
    assert False
```

Resolves #30
Example implementation in a client application test suite: openculinary/backend#20