### PR TITLE
Clean up warnings from deprecated pytest-postgresql methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
                       'SQLAlchemy>=1.2.2',
                       'Flask-SQLAlchemy>=2.3',
                       'packaging>=14.1'],
-    extras_require={'tests': ['pytest-postgresql>=3.1.1', 'psycopg2-binary', 'pytest>=6.0.1']},
+    extras_require={'tests': ['pytest-postgresql>=3.0.0', 'psycopg2-binary', 'pytest>=6.0.1']},
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Plugins',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
                       'SQLAlchemy>=1.2.2',
                       'Flask-SQLAlchemy>=2.3',
                       'packaging>=14.1'],
-    extras_require={'tests': ['pytest-postgresql>=2.4.0', 'psycopg2-binary', 'pytest>=6.0.1']},
+    extras_require={'tests': ['pytest-postgresql>=3.1.1', 'psycopg2-binary', 'pytest>=6.0.1']},
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Plugins',

--- a/tests/_conftest.py
+++ b/tests/_conftest.py
@@ -6,8 +6,7 @@ import pytest
 import sqlalchemy as sa
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
-from pytest_postgresql.factories import (init_postgresql_database,
-                                         drop_postgresql_database)
+from pytest_postgresql.factories import DatabaseJanitor
 
 # Retrieve a database connection string from the shell environment
 try:
@@ -33,11 +32,19 @@ def database(request):
     pg_pass = DB_OPTS.get("password")
     pg_db = DB_OPTS["database"]
 
-    init_postgresql_database(pg_user, pg_host, pg_port, pg_db, pg_pass)
+    janitor = DatabaseJanitor(
+        user=pg_user,
+        host=pg_host,
+        port=pg_port,
+        db_name=pg_db,
+        version='9.6',
+        password=pg_pass
+    )
+    janitor.init()
 
     @request.addfinalizer
     def drop_database():
-        drop_postgresql_database(pg_user, pg_host, pg_port, pg_db, 9.6, pg_pass)
+        janitor.drop()
 
 
 @pytest.fixture(scope='session')

--- a/tests/_conftest.py
+++ b/tests/_conftest.py
@@ -36,7 +36,7 @@ def database(request):
         user=pg_user,
         host=pg_host,
         port=pg_port,
-        db_name=pg_db,
+        dbname=pg_db,
         version='9.6',
         password=pg_pass
     )

--- a/tests/_conftest.py
+++ b/tests/_conftest.py
@@ -6,7 +6,7 @@ import pytest
 import sqlalchemy as sa
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
-from pytest_postgresql.factories import DatabaseJanitor
+from pytest_postgresql.janitor import DatabaseJanitor
 
 # Retrieve a database connection string from the shell environment
 try:

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -75,7 +75,7 @@ def test_missing_db_fixture(testdir):
         import sqlalchemy as sa
         from flask import Flask
         from flask_sqlalchemy import SQLAlchemy
-        from pytest_postgresql.factories import DatabaseJanitor
+        from pytest_postgresql.janitor import DatabaseJanitor 
 
         # Retrieve a database connection string from the shell environment
         try:

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -75,7 +75,7 @@ def test_missing_db_fixture(testdir):
         import sqlalchemy as sa
         from flask import Flask
         from flask_sqlalchemy import SQLAlchemy
-        from pytest_postgresql.janitor import DatabaseJanitor 
+        from pytest_postgresql.janitor import DatabaseJanitor
 
         # Retrieve a database connection string from the shell environment
         try:

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -75,8 +75,7 @@ def test_missing_db_fixture(testdir):
         import sqlalchemy as sa
         from flask import Flask
         from flask_sqlalchemy import SQLAlchemy
-        from pytest_postgresql.factories import (init_postgresql_database,
-                                                drop_postgresql_database)
+        from pytest_postgresql.factories import DatabaseJanitor
 
         # Retrieve a database connection string from the shell environment
         try:
@@ -102,11 +101,19 @@ def test_missing_db_fixture(testdir):
             pg_pass = DB_OPTS.get("password")
             pg_db = DB_OPTS["database"]
 
-            init_postgresql_database(pg_user, pg_host, pg_port, pg_db, pg_pass)
+            janitor = DatabaseJanitor(
+                user=pg_user,
+                host=pg_host,
+                port=pg_port,
+                db_name=pg_db,
+                version='9.6',
+                password=pg_pass
+            )
+            janitor.init()
 
             @request.addfinalizer
             def drop_database():
-                drop_postgresql_database(pg_user, pg_host, pg_port, pg_db, 9.6, pg_pass)
+                janitor.drop()
 
 
         @pytest.fixture(scope='session')

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -105,7 +105,7 @@ def test_missing_db_fixture(testdir):
                 user=pg_user,
                 host=pg_host,
                 port=pg_port,
-                db_name=pg_db,
+                dbname=pg_db,
                 version='9.6',
                 password=pg_pass
             )


### PR DESCRIPTION
Resolves #43.

(this is a repeat of #44; the origin repo and branch on GitHub had been deleted prior to review feedback)