### PR TITLE
Support Python 3.8, 3.9, and 3.10 and drop support for 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6.x, 3.7.x]
+        python: [3.7.x, 3.8.x, 3.9.x, 3.10.x]
         sqlalchemy: [1.2.*, 1.3.*, 1.4.*]
     services:
       postgres:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
                       'SQLAlchemy>=1.2.2',
                       'Flask-SQLAlchemy>=2.3',
                       'packaging>=14.1'],
-    extras_require={'tests': ['pytest-postgresql>=2.4.0', 'psycopg2-binary', 'pytest>=6.0.1']},
+    extras_require={'tests': ['pytest-postgresql>=2.4.0,<4.0.0', 'psycopg2-binary', 'pytest>=6.0.1']},
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Plugins',


### PR DESCRIPTION
Python 3.6 is end-of-life: https://peps.python.org/pep-0494/