### PR TITLE
Fix flask-sqlalchemy regression

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         python: [3.7.x, 3.8.x, 3.9.x, 3.10.x]
         sqlalchemy: [1.2.*, 1.3.*, 1.4.*]
+        flask_sqlalchemy: [2.*, 3.*]
     services:
       postgres:
         image: postgres:11
@@ -36,7 +37,9 @@ jobs:
         pip install --upgrade pip
         pip install -e .[tests]
         pip install --upgrade sqlalchemy=="${SQLALCHEMY_VERSION}"
+        pip install --upgrade flask-sqlalchemy=="${FLASK_SQLALCHEMY_VERSION}"
         pytest
       env:
         TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/pytest_test
         SQLALCHEMY_VERSION: ${{ matrix.sqlalchemy }}
+        FLASK_SQLALCHEMY_VERSION: ${{ matrix.flask_sqlalchemy }}

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -35,7 +35,13 @@ def _transaction(request, _db, mocker):
     # when specifying a `bind` option, or else Flask-SQLAlchemy won't scope
     # the connection properly
     options = dict(bind=connection, binds={})
-    session = _db.create_scoped_session(options=options)
+    try:
+        create_scoped_session = _db.create_scoped_session
+    except AttributeError:
+        # For Flask-SQLAlchemy version > 3.0
+        create_scoped_session = _db._make_scoped_session
+
+    session = create_scoped_session(options=options)
 
     # Make sure the session, connection, and transaction can't be closed by accident in
     # the codebase


### PR DESCRIPTION
In the latest version of Flask-SQLAlchemy, the method `SQLAlchemy.create_scoped_session` was renamed to `SQLAlchemy._make_scoped_session`, which causes a regression. I've added handling for this regression. I've also updated the workflows to test against Flask-SQLAlchemy 2 and 3.

I confirmed that this fix works by making the modification in a `venv/` in which I am using `pytest-flask-sqlalchemy` and then running my tests with the changes.

