### PR TITLE
fix flask-sqlalchemy regression

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         python: [3.7.x, 3.8.x, 3.9.x, 3.10.x]
         sqlalchemy: [1.2.*, 1.3.*, 1.4.*]
+        flask_sqlalchemy: [2.*, 3.*]
     services:
       postgres:
         image: postgres:11
@@ -36,7 +37,9 @@ jobs:
         pip install --upgrade pip
         pip install -e .[tests]
         pip install --upgrade sqlalchemy=="${SQLALCHEMY_VERSION}"
+        pip install --upgrade flask-sqlalchemy=="${FLASK_SQLALCHEMY_VERSION}"
         pytest
       env:
         TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/pytest_test
         SQLALCHEMY_VERSION: ${{ matrix.sqlalchemy }}
+        FLASK_SQLALCHEMY_VERSION: ${{ matrix.flask_sqlalchemy }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,8 @@ jobs:
       matrix:
         python: [3.7.x, 3.8.x, 3.9.x, 3.10.x]
         sqlalchemy: [1.2.*, 1.3.*, 1.4.*]
-        flask_sqlalchemy: [2.*, 3.*]
+        flask_sqlalchemy: [2.*]
+        # flask_sqlalchemy: [2.*, 3.*]
     services:
       postgres:
         image: postgres:11

--- a/pytest_flask_sqlalchemy/fixtures.py
+++ b/pytest_flask_sqlalchemy/fixtures.py
@@ -35,7 +35,13 @@ def _transaction(request, _db, mocker):
     # when specifying a `bind` option, or else Flask-SQLAlchemy won't scope
     # the connection properly
     options = dict(bind=connection, binds={})
-    session = _db.create_scoped_session(options=options)
+    try:
+        create_scoped_session = _db.create_scoped_session
+    except AttributeError:
+        # For Flask-SQLAlchemy version > 3.0
+        create_scoped_session = _db._make_scoped_session
+
+    session = create_scoped_session(options=options)
 
     # Make sure the session, connection, and transaction can't be closed by accident in
     # the codebase


### PR DESCRIPTION
To be honest, I have no idea how to make the tests pass for this repo for Flask-SQLAlchemy 3.x; I'd spent a few hours trying with no avail; it's more complicated than just running tests in a live app context. Sorry 😦 Raw SQL seems to work, but the ORM does not, is the extent of what I remember.

However, in my experience and despite the tests for this build not working, this _does_ fix a regression for Flask-SQLAlchemy 3.0, as long as the end-user also yields the `SQLAlchemy()` object in the app context.